### PR TITLE
Beautifully finalize bar in case of unexpected errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Do note that this console is heavily instrumented and has more overhead, so the 
 
 
 ## Changelog highlights:
+- 1.3.2: beautifully finalize bar in case of unexpected errors
 - 1.3.1: fix a subtle race condition that could leave artifacts if ended very fast, flush print buffer when position changes or bar terminates, keep total argument from unexpected types
 - 1.3.0: new fps calibration system, support force_tty and manual options in global configuration, multiple increment support in bar handler
 - 1.2.0: filled blanks bar styles, clean underflow representation of filled blanks

--- a/alive_progress/__init__.py
+++ b/alive_progress/__init__.py
@@ -11,7 +11,7 @@ from .spinners import bouncing_spinner_factory, compound_spinner_factory, delaye
     frame_spinner_factory, scrolling_spinner_factory, spinner_player
 from .styles import BARS, SPINNERS, THEMES
 
-VERSION = (1, 3, 1)
+VERSION = (1, 3, 2)
 
 __author__ = 'Rogério Sampaio de Almeida'
 __email__ = 'rsalmei@gmail.com'

--- a/alive_progress/progress.py
+++ b/alive_progress/progress.py
@@ -1,12 +1,11 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import sys
-from contextlib import contextmanager
-
 import math
+import sys
 import threading
 import time
+from contextlib import contextmanager
 from datetime import timedelta
 
 from .configuration import config_handler

--- a/alive_progress/progress.py
+++ b/alive_progress/progress.py
@@ -264,5 +264,5 @@ def alive_bar(total=None, title=None, calibrate=None, **options):
             thread = None  # lets the internal thread terminate gracefully.
             local_copy.join()
 
-    end, run.text, run.stats = True, '', stats_end
-    alive_repr()
+        end, run.text, run.stats = True, '', stats_end
+        alive_repr()


### PR DESCRIPTION
Instead of this (note the end of the line):
```
---------------------------------------------------------------------------eta: 0:01:37)
ZeroDivisionError                         Traceback (most recent call last)
```

we have:
```
|█▏⚠                                     | (!) 30/1000 [3%] in 3.0s (9.91/s)
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
```