### PR TITLE
Make enrichment optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ I like to think of it as a new kind of progress bar for python, as it has among 
   - a visual feedback of the current speed/throughput, as the spinner runs faster or slower according to the actual processing speed;
   - an efficient multi-threaded bar, which updates itself at a fraction of the actual speed (1,000,000 iterations per second equates to roughly 60fps refresh rate) to keep CPU usage low and avoid terminal spamming; (📌 new: you can now calibrate this!)
   - an expected time of arrival (eta), that shows the remaining processing time in a friendly way, not anything like `eta: 1584s`, it will nicely show `eta: 0:26:24` as you would expect (but anything less than a minute is indeed `eta: 42s`);
-  - a `print()` hook, which allows print statements in the midst of an alive-bar context, nicely cleaning the output of any garbage, and even enriching with the current count when it occurred;
+  - a `print()` hook, which allows print statements in the midst of an alive-bar context, nicely cleaning the output of any garbage, and even enriching with the current position when it occurred;
   - after your processing has finished, a nice receipt is printed with the statistics of that run, including the elapsed time and observed throughput;
   - it tracks the actual count in regard of the expected count, so it will look different if you send in more or less than expected;
   - it automatically detects if there's really an allocated tty, and if there isn't, only the final receipt is printed, so you can safely include the alive-bar in all and any code and rest assure your log file won't get 60fps garbage;
@@ -78,32 +78,31 @@ with alive_bar(3) as bar:
 ## Alive-Bar modes
 
 Actually, the `total` argument is optional. Providing it makes the bar enter the **definite mode**, the one used for well-bounded tasks. This mode has all statistics widgets the alive-bar has to offer: counter, throughput and eta.
-This is the only mode that tracks and displays overflow and underflow of items.
 
-If you do not provide a `total`, the bar enters the **unknown mode**. In this mode, the whole progress-bar is animated like the cool spinners, as it's not possible to determine the percentage of completion. Therefore it's also not possible to compute an eta, but you still get the counter and throughput widgets (note the cool spinners are still present in this mode, and each animation runs independently of each other, rendering a unique show in your terminal 😜).
+If you do not provide a `total`, the bar enters the **unknown mode**. In this mode, the whole progress-bar is animated like the cool spinners, as it's not possible to determine the percentage of completion. Therefore it's also not possible to compute an eta, but you still get the counter and throughput widgets. And the cool spinners are still present in this mode, so each animation runs independently of each other, rendering a unique show in your terminal 😜.
 
-Then you have the (📌 new) **manual modes**, where you get to manually control the bar!
-Just pass a `manual=True` argument to `alive_bar()` or `config_handler.set_global()`, and you get to send a percentage to the very same `bar()` handler, and put the alive-bar in wherever position you want! For example to send 15%, you would send 0.15 which is 15 / 100.
-Call it as frequently as you need, the refresh rate will be asynchronously computed according to the sent progress and the actual elapsed time.
+Then you have the (📌 new) **manual mode**, where you get to actually control the bar! That way, you can put it in whatever position you want, like make it go backwards, or act like a gauge of some sort!
+Just pass a `manual=True` argument to `alive_bar()` (or `config_handler.set_global()`), and you get to send a percentage to the very same `bar()` handler to put the alive-bar where you want! For example to send 15%, you would call `bar(0.15)` (which is 15 / 100).
+Call it as frequently as you need, the refresh rate will be asynchronously computed according to the progress and the elapsed time, not the update rate.
 
-In these modes, you can also provide the `total` to enter the **manual definite mode**, and get all the same counter, throughput and eta statistics widgets as the _auto definite mode_. The counter is inferred from the supplied percentage.
-Or you can omit the `total` to enter the **manual unknown mode**, where it's not possible to infer neither the counter nor the throughput widgets, and you get a simpler "percent/second" (%/s) and a rough eta, calculated to get to 100%.
+And of course, in this mode you can also provide the `total`, and get all the same counter, throughput and eta statistics widgets as the _definite mode_. The counter is inferred from the supplied percentage.
+If you omit the `total`, it's not possible to infer neither the counter nor the throughput widgets, and you get a simpler "percent/second" (%/s) and a rough eta, calculated to get to 100%.
 
-So, to summarize it all:
+> Just remember: You do not have to think about which mode you should be using, just always pass a `total` if you know it, and use `manual` if you need it! It will just work! 👏
 
-| mode | automatic | total | percentage | counter | throughput | eta | outstanding features |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| definite        | ✅ | ✅ | ✅ | ✅            | ✅           | ✅ | overflow and underflow |
-| unknown         | ✅ | ❌ | ❌ | ✅            | ✅           | ❌ | super cool animations |
-| manual definite | ❌ | ✅ | ✅ | ✅ (inferred) | ✅           | ✅ | choose any completion |
-| manual unknown  | ❌ | ❌ | ✅ | ❌            | ⚠️ (simpler) | ✅ | choose any completion |
+To summarize it all:
 
-> Just remember: You do not have to think about which mode you should be using, just pass a `total` if you have one, and use `manual` if your processing needs it! 👏
+| mode | positioning | counter | throughput | eta | overflow and underflow |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| definite (with total)   | ✅ automatic  | ✅          | ✅           | ✅ | ✅ |
+| unknown (without total) | ❌            | ✅          | ✅           | ❌ | ❌ |
+| manual (with total)     | ✅ you choose | ✅ inferred | ✅           | ✅ | ✅ |
+| manual (without total)  | ✅ you choose | ❌          | ⚠️ simpler | ⚠️ rough | ✅ |
 
 
 ### Signatures of the `bar()` handler
 
-- in **automatic** modes: `bar(text=None, incr=1)` ➔ increases the current count (by any positive increment), optionally setting the situational text message, and returns the new count;
+- in **definite and unknown** modes: `bar(text=None, incr=1)` ➔ increases the current count (by any positive increment), optionally setting the situational text message, and returns the new count;
 - in **manual** modes: `bar(perc=None, text=None)` ➔ sets the new progress percentage, optionally setting the situational text message, and returns the new percentage.
 
 
@@ -113,7 +112,7 @@ Wondering what styles does it have bundled? It's `showtime`! ;)
 
 ![alive-progress spinner styles](https://raw.githubusercontent.com/rsalmei/alive-progress/master/img/showtime-spinners.gif)
 
-I've made these styles to test all combinations of parameters of the factories, but I think some of them ended up very very cool! Use them, or create your own!
+Actually I've made these styles just to put to use all combinations of the factories I've created, but I think some of them ended up very very cool! Use them at will, or create your own!
 
 There's also a bars `showtime`, check it out! ;)
 
@@ -124,9 +123,9 @@ There's also a bars `showtime`, check it out! ;)
 
 While in an alive progress bar context, you have two ways to output messages:
   - calling `bar(text='message')`, which sets/overwrites a situational message within the bar line, usually to display something about the items being processed, or the phase the processing is in;
-  - calling the usual Python `print('message')`, which will print an enriched message that includes the current position of the alive bar, thus leaving behind a log and continuing the bar below it.
+  - calling the usual Python `print()` statement, which will print an enriched message that includes the current position of the alive bar, thus leaving behind a cool log and continuing the bar below it.
 
-Both methods work the same in **definite**, **unknown** and **manual** modes, and always clear the line appropriately to remove any garbage on screen.
+Both methods work the same in all modes, and always clear the line appropriately to remove any garbage on screen.
 
 ![alive-progress messages](https://raw.githubusercontent.com/rsalmei/alive-progress/master/img/printing.gif)
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,11 @@ Do note that this console is heavily instrumented and has more overhead, so the 
 - It does not have any dependencies.
 
 
+## Python 2 EOL
+
+The version 1.4.0 is the last one to support Python 2.
+
+
 ## Changelog highlights:
 - 1.4.0: print() enrichment can now be disabled (locally and globally), exhibits now have a real time fps indicator, new exhibit functions `show_spinners` and `show_bars`, new utility `print_chars`, `show_bars` gains some advanced demonstrations (try it again!)
 - 1.3.3: further improve stream compatibility with isatty

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ There's also a bars `showtime`, check it out! ;)
 
 ![alive-progress bar styles](https://raw.githubusercontent.com/rsalmei/alive-progress/master/img/showtime-bars.gif)
 
+(📌 new) Now there's new commands in exhibition! Try the `show_bars()` and `show_spinners()`! Just:
+ 
+```python
+from alive_progress import show_bars, show_spinners
+# call them!
+```
+
+Enjoy ;)
+
+There's also a new utility called `print_chars`, to help finding that cool one to put in your customized spinner or bar, or to determine if your terminal support unicode chars.
+
 
 ## Printing messages
 
@@ -147,6 +158,7 @@ The options are:
 - `theme`: theme name in alive_progress.THEMES
 - `force_tty`: runs animations even without a tty (pycharm terminal for example)
 - `manual`: set to manually control percentage
+- `enrich_print`: enabled by default, unset to remove the bar position from print() messages
 
 And you can mix and match them, global and local! (_Click to see it in motion_)
 
@@ -279,6 +291,7 @@ Do note that this console is heavily instrumented and has more overhead, so the 
 
 
 ## Changelog highlights:
+- 1.4.0: print() enrichment can now be disabled (locally and globally), exhibits now have a real time fps indicator, new exhibit functions `show_spinners` and `show_bars`, new utility `print_chars`, `show_bars` gains some advanced demonstrations (try it again!)
 - 1.3.3: further improve stream compatibility with isatty
 - 1.3.2: beautifully finalize bar in case of unexpected errors
 - 1.3.1: fix a subtle race condition that could leave artifacts if ended very fast, flush print buffer when position changes or bar terminates, keep total argument from unexpected types

--- a/alive_progress/__init__.py
+++ b/alive_progress/__init__.py
@@ -11,7 +11,7 @@ from .spinners import bouncing_spinner_factory, compound_spinner_factory, delaye
     frame_spinner_factory, scrolling_spinner_factory, spinner_player
 from .styles import BARS, SPINNERS, THEMES
 
-VERSION = (1, 3, 3)
+VERSION = (1, 4, 0)
 
 __author__ = 'Rogério Sampaio de Almeida'
 __email__ = 'rsalmei@gmail.com'

--- a/alive_progress/__init__.py
+++ b/alive_progress/__init__.py
@@ -24,5 +24,5 @@ __all__ = ['alive_bar', 'standard_bar_factory', 'unknown_bar_factory', 'spinner_
            'compound_spinner_factory', 'delayed_spinner_factory', 'BARS', 'SPINNERS', 'THEMES',
            'show_bars', 'show_chars', 'show_spinners', 'showtime', 'config_handler']
 
-if sys.version_info <= (3,):
+if sys.version_info < (3,):
     __all__ = [bytes(x) for x in __all__]

--- a/alive_progress/__init__.py
+++ b/alive_progress/__init__.py
@@ -5,7 +5,7 @@ import sys
 
 from .bars import standard_bar_factory, unknown_bar_factory
 from .configuration import config_handler
-from .exhibit import show_bars, show_chars, show_spinners, showtime
+from .exhibit import print_chars, show_bars, show_spinners, showtime
 from .progress import alive_bar
 from .spinners import bouncing_spinner_factory, compound_spinner_factory, delayed_spinner_factory, \
     frame_spinner_factory, scrolling_spinner_factory, spinner_player
@@ -22,7 +22,7 @@ __description__ = 'A new kind of Progress Bar, with real-time throughput, ' \
 __all__ = ['alive_bar', 'standard_bar_factory', 'unknown_bar_factory', 'spinner_player',
            'frame_spinner_factory', 'scrolling_spinner_factory', 'bouncing_spinner_factory',
            'compound_spinner_factory', 'delayed_spinner_factory', 'BARS', 'SPINNERS', 'THEMES',
-           'show_bars', 'show_chars', 'show_spinners', 'showtime', 'config_handler']
+           'print_chars', 'show_bars', 'show_spinners', 'showtime', 'config_handler']
 
 if sys.version_info < (3,):
     __all__ = [bytes(x) for x in __all__]

--- a/alive_progress/__init__.py
+++ b/alive_progress/__init__.py
@@ -5,7 +5,7 @@ import sys
 
 from .bars import standard_bar_factory, unknown_bar_factory
 from .configuration import config_handler
-from .exhibit import showtime
+from .exhibit import show_bars, show_chars, show_spinners, showtime
 from .progress import alive_bar
 from .spinners import bouncing_spinner_factory, compound_spinner_factory, delayed_spinner_factory, \
     frame_spinner_factory, scrolling_spinner_factory, spinner_player
@@ -16,12 +16,13 @@ VERSION = (1, 3, 3)
 __author__ = 'Rogério Sampaio de Almeida'
 __email__ = 'rsalmei@gmail.com'
 __version__ = '.'.join(map(str, VERSION))
-__description__ = 'An animated and smart Progress Bar for python.'
+__description__ = 'A new kind of Progress Bar, with real-time throughput, ' \
+                  'eta and very cool animations!'
 
 __all__ = ['alive_bar', 'standard_bar_factory', 'unknown_bar_factory', 'spinner_player',
            'frame_spinner_factory', 'scrolling_spinner_factory', 'bouncing_spinner_factory',
            'compound_spinner_factory', 'delayed_spinner_factory', 'BARS', 'SPINNERS', 'THEMES',
-           'showtime', 'config_handler']
+           'show_bars', 'show_chars', 'show_spinners', 'showtime', 'config_handler']
 
 if sys.version_info <= (3,):
     __all__ = [bytes(x) for x in __all__]

--- a/alive_progress/bars.py
+++ b/alive_progress/bars.py
@@ -41,7 +41,7 @@ def standard_bar_factory(chars='=', borders='||', blank=' ', tip='>', errors='!x
 def unknown_bar_factory(spinner_factory):
     def inner_factory(length, receipt_bar_factory=None):
         # noinspection PyUnusedLocal
-        def draw_bar(percent, end=False):
+        def draw_bar(percent=None, end=False):
             if end:
                 return receipt_bar(1., end=True)
             # noinspection PyUnresolvedReferences

--- a/alive_progress/configuration.py
+++ b/alive_progress/configuration.py
@@ -47,6 +47,7 @@ CONFIG_VARS = dict(
     unknown=_style_input_factory(SPINNERS, bars, 1),
     force_tty=_bool_input_factory(),
     manual=_bool_input_factory(),
+    enrich_print=_bool_input_factory(),
 )
 
 Config = namedtuple('Config', tuple(CONFIG_VARS.keys()))
@@ -61,6 +62,7 @@ def create_config():
             theme='smooth',  # includes spinner, bar and unknown.
             force_tty=False,
             manual=False,
+            enrich_print=True,
         )
 
     def set_global(theme=None, **options):

--- a/alive_progress/configuration.py
+++ b/alive_progress/configuration.py
@@ -84,14 +84,14 @@ def create_config():
             try:
                 result = CONFIG_VARS[key](value)
                 if result is None:
-                    raise ValueError('invalid option value: {}={}'.format(key, repr(value)))
+                    raise ValueError('invalid config value: {}={}'.format(key, repr(value)))
                 return key, result
             except KeyError:
-                raise ValueError('invalid option name: ' + key)
+                raise ValueError('invalid config name: {}'.format(key))
 
         if theme:
             if theme not in THEMES:
-                raise ValueError('invalid theme={}'.format(repr(theme)))
+                raise ValueError('invalid theme name={}'.format(repr(theme)))
             swap = options
             options = deepcopy(THEMES[theme])
             options.update(swap)

--- a/alive_progress/exhibit.py
+++ b/alive_progress/exhibit.py
@@ -1,6 +1,9 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import random
+import sys
+import time
 from collections import OrderedDict
 
 from .configuration import config_handler
@@ -8,58 +11,72 @@ from .spinners import spinner_player
 from .styles import BARS, SPINNERS
 
 
-def showtime(fps=15, spinners=True, **options):
-    def bar_gen(bar_factory, end):
-        total = int(config.length * 4)
-        bar = bar_factory(config.length)
-        while True:
-            for t in total, int(total * .6), int(total + 1):
-                for pos in range(t):
-                    percent = float(pos) / total
-                    yield bar(percent), '\n'
-                if end:
-                    percent = float(t) / total
-                    for pos in range(int(fps * 2)):
-                        yield bar(percent, end=True), '\n'
+def showtime(fps=None, spinners=True, **options):
+    """Start a show, rendering all styles simultaneously in your screen.
 
-    def spinner_gen(key, spinner_factory, unknown_factory):
-        blanks = ' ' * (longest - spinner_lengths[key])
-        player = spinner_player(spinner_factory())
-        unknown = bar_gen(unknown_factory, False)
-        while True:
-            yield blanks, next(player), next(unknown)[0]
-
-    config = config_handler(**options)
-
+    Args:
+        fps (float): the desired frames per second rendition
+        spinners (bool): shows spinners if True, or bars otherwise
+        options (dict): configuration options
+    """
     if spinners:
-        spinner_lengths = {k: v[0].natural for k, v in SPINNERS.items()}
-        longest = max(spinner_lengths.values()) + 2
-        max_name_length = max(map(lambda x: len(x), SPINNERS.keys())) + 2
-        prepared_gen = OrderedDict(('{:^{}}'.format(k, max_name_length), spinner_gen(k, s, u))
-                                   for k, (s, u) in SPINNERS.items())
-        displaying, line_pattern = 'spinners (and equivalent unknown bars)', '{1}|{2}| {0} {3}'
-        total_lines = 1 + len(prepared_gen)
+        show_spinners(fps, **options)
     else:
-        max_name_length = max(map(lambda x: len(x), BARS.keys())) + 2
-        prepared_gen = OrderedDict(('{:>{}}'.format(k, max_name_length), bar_gen(b, True))
-                                   for k, b in BARS.items())
-        displaying, line_pattern = 'bars', '{0} {1}{2}'
-        total_lines = 1 + len(prepared_gen) * 2
+        show_bars(fps, **options)
 
-    sleep = 1. / fps
-    print('\nalive-progress bars, enjoy :)')
-    print('==========================')
-    print('fps:', fps, '(sleep: {:.3f}s)'.format(sleep))
-    print('\npreconfigured {}:'.format(displaying))
 
-    import time
+def show_spinners(fps=None, **options):
+    """Start a spinner show, rendering all styles simultaneously in your screen.
+
+    Args:
+        fps (float): the desired frames per second rendition
+        options (dict): configuration options
+    """
+    max_name_length = max(map(lambda x: len(x), SPINNERS.keys())) + 2
+    prepared_gen = OrderedDict(('{:^{}}'.format(k, max_name_length), _spinner_gen(k, s, u))
+                               for k, (s, u) in SPINNERS.items())
+    displaying, line_pattern = 'spinners, with their unknown bar renditions', '{1}|{2}| {0} {3}'
+    total_lines = 1 + len(prepared_gen)
+    _showtime_gen(fps, prepared_gen, displaying, line_pattern, total_lines, **options)
+
+
+def show_bars(fps=None, **options):
+    """Start a bar show, rendering all styles simultaneously in your screen.
+
+    Args:
+        fps (float): the desired frames per second rendition
+        options (dict): configuration options
+    """
+    max_name_length = max(map(lambda x: len(x), BARS.keys())) + 2
+    prepared_gen = OrderedDict(('{:>{}}'.format(k, max_name_length), _bar_gen(b))
+                               for k, b in BARS.items())
+    displaying, line_pattern = 'bars', '{0} {1}{2}'
+    total_lines = 1 + 2 * len(prepared_gen)
+    _showtime_gen(fps, prepared_gen, displaying, line_pattern, total_lines, **options)
+
+
+def _showtime_gen(fps, prepared_gen, displaying, line_pattern, total_lines, **options):
+    sleep, config = 1. / fps, config_handler(**options)
+
+    print('Welcome to alive-progress, enjoy! (ctrl+c to stop :)')
+    print('=================================')
+    print('showing: preconfigured {}'.format(displaying))
+    print('--> remember you can create your own!\n')
+
+    # initialize the generators, sending fps and config params (list comprehension is discarded).
+    [(next(gen), gen.send((fps, config))) for gen in prepared_gen.values()]
+
+    total_lines += 1  # frames per second indicator.
+    up_command = '\033[{}A'.format(total_lines)  # ANSI escape sequence for Cursor Up.
+    start, frame = timer(), 0
+    start, current = start - sleep, start  # simulates the first frame took exactly "sleep" ms.
     try:
         while True:
             for name, gens in prepared_gen.items():
                 print(line_pattern.format(name, *next(gens)))
 
             time.sleep(sleep)
-            print('\033[{}A'.format(total_lines))
+            print(up_command)
     except KeyboardInterrupt:
         pass
 
@@ -67,9 +84,37 @@ def showtime(fps=15, spinners=True, **options):
 def show_chars(line=64):
     def pos():
         return i * line + 32
+def _bar_gen(bar_factory):
+    fps, config = yield
+    total = int(config.length * 2)
+    bar = bar_factory(config.length)
+    while True:
+        # standard use cases, increment till completion, underflow and overflow.
+        for t in total, int(total * .6), int(total + 1):
+            for pos in range(t):
+                percent = float(pos) / total
+                yield bar(percent), '\n'
+            # generates a small pause in movement between cases, based on fps.
+            percent = float(t) / total
+            for pos in range(int(fps * 2)):
+                yield bar(percent, end=True), '\n'
 
-    for i in range(185):
-        print(pos(), end=': ')
-        for j in range(line):
-            print(chr(pos() + j), end=' ')
+        # advanced use cases, which do not go only forward.
+        for t in [1. - float(x) / total for x in range(total)], \
+                 [random.random() for _ in range(total)]:
+            for percent in t:
+                yield bar(percent), '\n'
+
+
+def _spinner_gen(key, spinner_factory, unknown_factory):
+    fps, config = yield
+    spinner_lengths = {k: v[0].natural for k, v in SPINNERS.items()}
+    longest = max(spinner_lengths.values()) + 2
+    blanks = ' ' * (longest - spinner_lengths[key])
+    player = spinner_player(spinner_factory())
+    unknown = unknown_factory(config.length)
+    while True:
+        yield blanks, next(player), unknown()
+
+
         print()

--- a/alive_progress/exhibit.py
+++ b/alive_progress/exhibit.py
@@ -89,9 +89,6 @@ def _showtime_gen(fps, prepared_gen, displaying, line_pattern, total_lines, **op
         pass
 
 
-def show_chars(line=64):
-    def pos():
-        return i * line + 32
 def _bar_gen(bar_factory):
     fps, config = yield
     total = int(config.length * 2)
@@ -125,4 +122,21 @@ def _spinner_gen(key, spinner_factory, unknown_factory):
         yield blanks, next(player), unknown()
 
 
+def print_chars(line_length=32, max_char=0x2e80):
+    """Print all chars in your terminal, to help you find that cool one to put in your
+    customized spinner or bar. Also useful to determine which ones your terminal support.
+
+    Args:
+        line_length (int): the desired characters per line
+        max_char (int): the last character in the unicode table to show
+            this goes up to 0x10ffff, but after the default value, it seems to return
+            only japanese ideograms, increase this if would like to see them.
+    """
+    char = chr if sys.version_info >= (3,) else unichr
+    max_char = min(0x10ffff, max(0, max_char))
+    num_lines = int(max_char / line_length)
+    for i in map(lambda x: x * line_length + 32, range(num_lines)):
+        print(hex(i), end=': ')
+        for j in range(line_length):
+            print(char(i + j), end=' ')
         print()

--- a/alive_progress/progress.py
+++ b/alive_progress/progress.py
@@ -217,11 +217,14 @@ def alive_bar(total=None, title=None, calibrate=None, **options):
         logic_total, format_spec, factor, current = 1., '%', 1., lambda: run.percent
 
     # calibration of the dynamic fps engine.
-    # y = log10(x + m) * f + n, where y is fps, (m, n) are horizontal and vertical translation,
-    #   and f is a calibration factor, computed from an user input c.
-    # fps = log10(x + 1) * f + minfps, which must be equal to maxfps for x = c,
-    # so the factor f = (maxfps - minfps) / log10(c + 1), and
-    # fps = log10(x + 1) * (maxfps - minfps) / log10(c + 1) + minfps
+    # I've started with the equation y = log10(x + m) * k + n, where:
+    #   y is the desired fps, m and n are horizontal and vertical translation,
+    #   k is a calibration factor, computed from some user input c (see readme for details).
+    # considering minfps and maxfps as given constants, I came to:
+    #   fps = log10(x + 1) * k + minfps, which must be equal to maxfps for x = c,
+    # so the factor k = (maxfps - minfps) / log10(c + 1), and
+    #   fps = log10(x + 1) * (maxfps - minfps) / log10(c + 1) + minfps
+    # neat! ;)
     min_fps, max_fps = 2., 60.
     calibrate = max(0., calibrate or factor)
     adjust_log_curve = 100. / min(calibrate, 100.)  # adjust curve for small numbers

--- a/alive_progress/progress.py
+++ b/alive_progress/progress.py
@@ -56,10 +56,10 @@ def alive_bar(total=None, title=None, calibrate=None, **options):
 
     If the bar is over or underused, it will warn you!
     To test all supported scenarios, you can do this:
-    >>> for x in 3000, 4000, 2000, 0:
+    >>> for x in 1000, 1500, 700, 0:
     ...    with alive_bar(x) as bar:
-    ...        for i in range(3000):
-    ...            time.sleep(.002)
+    ...        for i in range(1000):
+    ...            time.sleep(.005)
     ...            bar()
     Expected results are these (but you have to see them in motion!):
 [========================================] 3000/3000 [100%] in 7.4s (408.09/s)

--- a/alive_progress/progress.py
+++ b/alive_progress/progress.py
@@ -158,14 +158,16 @@ def alive_bar(total=None, title=None, calibrate=None, **options):
     print_lock = threading.Lock()
 
     def start_monitoring(offset=0.):
-        sys.stdout = print_hook
+        if config.enrich_print:
+            sys.stdout = print_hook
         event.set()
         run.init = time.time() - offset
 
     def stop_monitoring(clear):
         if clear:
             event.clear()
-        sys.stdout = sys.__stdout__
+        if config.enrich_print:
+            sys.stdout = sys.__stdout__
         return time.time() - run.init
 
     thread, event = None, threading.Event()

--- a/alive_progress/styles.py
+++ b/alive_progress/styles.py
@@ -103,10 +103,10 @@ def __create_bars():
     smooth = standard_bar_factory(chars='▏▎▍▌▋▊▉█', tip=None, errors='⚠✗')
     blocks = standard_bar_factory(chars='▏▎▍▌▋▊▉', tip=None, errors='⚠✗')
     bubbles = standard_bar_factory(chars='∙○⦿●', borders='<>', tip='', errors='⚠✗')
-    hollow = standard_bar_factory(chars='❒', borders='<>', tip='▷', errors='⚠✗')
-    solid = standard_bar_factory(chars='■', borders='<>', tip='►', errors='⚠✗')
     circles = standard_bar_factory(blank='○', chars='●', borders='<>', tip='', errors='⚠✗')
+    hollow = standard_bar_factory(chars='❒', borders='<>', tip='▷', errors='⚠✗')
     squares = standard_bar_factory(blank='❒', chars='■', borders='<>', tip='', errors='⚠✗')
+    solid = standard_bar_factory(chars='■', borders='<>', tip='►', errors='⚠✗')
     checks = standard_bar_factory(chars='✓', tip='', errors='⚠✗')
     filling = standard_bar_factory(chars='▁▂▃▄▅▆▇█', tip=None, errors='⚠✗')
 

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,9 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
-    keywords='progress bar spinner progress-bar eta monitoring python terminal '
+    keywords='progress bar progress-bar progressbar spinner eta monitoring python terminal '
              'multi-threaded REPL alive animated visual feedback'.split(),
     packages=find_packages(),
     python_requires='>=2.7, <4',
+    install_requires=[],
 )


### PR DESCRIPTION
## Changelog highlights:
- 1.4.0: print() enrichment can now be disabled (locally and globally), exhibits now have a real time fps indicator, new exhibit functions `show_spinners` and `show_bars`, new utility `print_chars`, `show_bars` gains some advanced demonstrations (try it again!)
