### PR TITLE
Fix #112 - Alive_bar() crashes when printing with click.echo

### DIFF
--- a/alive_progress/core/hook_manager.py
+++ b/alive_progress/core/hook_manager.py
@@ -33,7 +33,8 @@ def buffered_hook_manager(header_template, get_pos, cond_refresh, term):
 
     def write(stream, part):
         if isinstance(part, bytes):
-            part = part.decode('utf-8')
+            encoding = sys.getdefaultencoding()
+            part = part.decode(encoding)
         buffer = buffers[stream]
         if part != '\n':
             # this will generate a sequence of lines interspersed with None, which will later

--- a/alive_progress/core/hook_manager.py
+++ b/alive_progress/core/hook_manager.py
@@ -32,6 +32,8 @@ def buffered_hook_manager(header_template, get_pos, cond_refresh, term):
             stream.flush()
 
     def write(stream, part):
+        if isinstance(part, bytes):
+            part = part.decode('utf-8')
         buffer = buffers[stream]
         if part != '\n':
             # this will generate a sequence of lines interspersed with None, which will later

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,4 +2,6 @@ ipython
 pdbpp
 twine
 wheel
+about-time
+grapheme
 nox  # although it is for testing, it is not needed inside each test scope.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pytest-sugar
+click # For testing bytes stdout on hook manager

--- a/tests/core/test_hook_manager.py
+++ b/tests/core/test_hook_manager.py
@@ -3,6 +3,7 @@ import sys
 from threading import Condition
 from contextlib import contextmanager
 from unittest import mock
+import click
 
 import pytest
 
@@ -23,6 +24,11 @@ def test_hook_manager_captures_stdout(capsys):
         print('ok')
     assert capsys.readouterr().out == 'nice 35! ok\n'
 
+def test_hook_manager_captures_bytes_stdout(capsys):
+    hook_manager = buffered_hook_manager('nice {}! ', lambda: 35, Condition(), FULL)
+    with hook(hook_manager):
+        click.echo('ok')
+    assert capsys.readouterr().out == 'nice 35! ok\n'
 
 # I couldn't make this work yet, there's some weird interaction
 # between my hook and the pytest one...


### PR DESCRIPTION
* Added a bytes check to the write function of the buffered_hook_manager. If the part to be written to the buffer is of bytes type, it is decoded into a string assuming utf-8 encoding before being added to the buffer.
* Added a test with a click.echo printing redirection.
* Fixed missing depencies in the dev.txt requirements file.
