### PR TITLE
Fix #151 - Disabled alive_bar crashes when using bar.text with dual_line option

### DIFF
--- a/alive_progress/utils/terminal/void.py
+++ b/alive_progress/utils/terminal/void.py
@@ -10,6 +10,7 @@ def _ansi_escape_sequence(_=''):
     def inner(_available=None):
         pass
 
+    inner.sequence = ''
     return inner
 
 


### PR DESCRIPTION
Bug #151 was traced back to line 141, inside the `set_text` function on `core.progress`:

```python
def set_text(text=None):
        if text and config.dual_line:
            run.text, run.suffix = ('\n', to_cells(str(text))), term.cursor_up_1.sequence
```
When the bar is disabled, `term` is set to `terminal.VOID` (line 204 of same file):

```python
if config.disable:
        term, hook_manager = terminal.VOID, passthrough_hook_manager()
```

However, when examining `terminal.VOID`, its `factory_cursor_up` function doesn't define a `sequence` attribute as the other terminals do (lines 9 - 15 of `utils.terminal.void`):

```python
def _ansi_escape_sequence(_=''):
    def inner(_available=None):
        pass

    return inner
```
which results in the exception being thrown, since `term.cursor_up_1` does not have a `.sequence` attribute.

I've fixed this by simply adding an empty sequence to void's `_ansi_escape_sequence`:

```python
def _ansi_escape_sequence(_=''):
    def inner(_available=None):
        pass

    inner.sequence = ''
    return inner
```