### PR TITLE
Showtime is not present under alive_progress.styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Just install with pip:
 
 If you're wondering what styles are builtin, it's `showtime`! ;)
 ```python
-from alive_progress.styles import showtime
+from alive_progress import showtime
 
 showtime()
 ```


### PR DESCRIPTION
I tried running the demo commands to check the alive_progress but it wast throwing out error :  ImportError: cannot import name showtime

So i just removed the styles and it was working fine.  I have made changes to the read me.