### PR TITLE
number format in Update progress.py

### DIFF
--- a/alive_progress/core/progress.py
+++ b/alive_progress/core/progress.py
@@ -272,7 +272,7 @@ def __alive_bar(config, total=None, *, calibrate=None,
 
     def monitor_run(f, precision=config.precision):
         run.monitor_text = human_count(run.count, precision)
-        return f.format(count=run.monitor_text, total=total_human, percent=run.percent)
+        return f.format(count=float(run.monitor_text), total=float(total_human), percent=run.percent)
 
     def monitor_end(f):
         warning = '(!) ' if total is not None and current() != logic_total else ''


### PR DESCRIPTION
Updated line 275 to allow for the number format to be introduced in the "monitor" and "monitor_end" parameters.

In the current code, monitor = ("{count:,}/{total:,} [{percent:3.1%}] - processing "), throws an error. 

By adding these mods, the error is gone and the display show all the python formats available. e.g. below: 

|████████████████████████████████████████| 1,000/1,000 [100.00%] - ### COMPLETED ###  in 15.8s (63.41/s)

I hope it doesn't ruins something else in the code.