### PR TITLE
Fix ValueError: Invalid config value: spinner=... for pyinstaller

### DIFF
--- a/alive_progress/core/configuration.py
+++ b/alive_progress/core/configuration.py
@@ -48,7 +48,7 @@ def __func_lookup(module_lookup, inner_name):
         if isinstance(x, FunctionType):
             func_file, _ = os.path.splitext(module_lookup.__file__)
             if x.__code__.co_name == inner_name \
-                    and os.path.splitext(x.__code__.co_filename)[0] == func_file:
+                    and func_file.endswith(os.path.splitext(x.__code__.co_filename)[0]):
                 return x
             return ERROR
 


### PR DESCRIPTION
This here works and one does not have to keep in mind any hardcoded path checks while potentially shuffling files around in the future.

I'd have liked to include a test but with being unable to set read-only `__code__.co_filename` in it, refactor of `_input()` to accept a `__code__`-like object would probably be necessary, cascading into more refactors in `__style_input()` and callers... you get the idea.

So I hope the one-liner is good enough.
