### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: main
 
-on: [push]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   main:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: 'pip'
         cache-dependency-path: setup.py
     - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/alive_progress/core/progress.py
+++ b/alive_progress/core/progress.py
@@ -6,7 +6,8 @@ import math
 import threading
 import time
 from contextlib import contextmanager
-from typing import Any, Callable, Collection, Iterable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
+from collections.abc import Collection, Iterable
 
 from .calibration import calibrated_fps, custom_fps
 from .configuration import config_handler

--- a/alive_progress/tools/demo.py
+++ b/alive_progress/tools/demo.py
@@ -69,7 +69,7 @@ def demo(sleep=None):
             for i in range(1, case.count + 1):
                 time.sleep(sleep or .003)
                 if manual:
-                    bar((float(i) / (total or case.count)))
+                    bar(float(i) / (total or case.count))
                 else:
                     bar()
                 if case.hooks and i:

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
     keywords='progress bar progress-bar progressbar spinner eta monitoring python terminal '
              'multi-threaded REPL alive animated visual feedback simple live efficient monitor '


### PR DESCRIPTION
Python 3.14 beta has been [released](https://discuss.python.org/t/python-3-14-0-beta-3-is-here/95843) and the release manager (👋 hi! that's me!) said:

> We ***strongly encourage*** maintainers of third-party Python projects to ***test with 3.14*** during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature-complete entering the beta phase, it is possible that features may be modified or, in rare cases, deleted up until the start of the release candidate phase (Tuesday 2025-07-22). Our goal is to have ***no ABI changes*** after beta 4 and as few code changes as possible after the first release candidate. To achieve that, it will be ***extremely important*** to get as much exposure for 3.14 as possible during the beta phase.



