### PR TITLE
Fallback to _fd=1 if .fileno is not a valid attribute

### DIFF
--- a/alive_progress/utils/terminal/tty.py
+++ b/alive_progress/utils/terminal/tty.py
@@ -8,7 +8,7 @@ def new(original, max_cols):
 
     try:
         _fd = original.fileno()
-    except OSError:
+    except (AttributeError, OSError):
         _fd = 1
 
     def cols():


### PR DESCRIPTION
Helps with Celery integration

Relates to https://github.com/rsalmei/alive-progress/issues/262 and https://github.com/rsalmei/alive-progress/issues/262#issuecomment-3318475112