### PR TITLE
Improve "finalize" argument example

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ for item in bar:  # <<-- iterate on bar
 Note that this is a slightly special `bar`, which does not support `bar()`, since the iterator adapter tracks items automatically for you. Also, it supports `finalize`, which enables you to set the title and/or text of the final receipt:
 
 ```python
-alive_it(items, finalize=lambda bar: bar.text('Success!'))
+alive_it(items, finalize=lambda bar: bar.text('Success!'), receipt_text=True)
 ...
 ```
 


### PR DESCRIPTION
`finalize` doesn't function as expected without `receipt_text=True`

https://github.com/rsalmei/alive-progress/issues/299#issuecomment-3587415786

Fixes #299