### PR TITLE
Allow receipt widgets to be changed through the bar handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next
+- allow final receipt widgets to be changed through the `bar` handle
+
 ## 3.3.0 - Jul 19, 2025
 - the final receipt is available in the alive_bar handle
 - the elapsed time is available in the alive_bar handle, in seconds with full precision

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ After a bar has finished (or even while running), you have a plethora of methods
 
 - `bar.text('message')` or `bar.text = 'message'`: set a situational message at the end of the bar, where you can display information about the current item or the phase the processing is in.
 - `bar.title('Title')` or `bar.title = 'Title'`: set a title at the beginning of the bar; can be set right when starting it or while it's running or even after finished to affect the receipt on demand — mix it with `title_length` config to keep the bar from changing its length while running.
+- `bar.monitor_end`, `bar.elapsed_end`, and `bar.stats_end`: change or hide the corresponding final receipt widgets while the bar is running or after it has finished. They accept the same boolean or format string values as the matching configuration options.
 - `bar.current`: retrieve the current bar count or percentage — more details below on Modes of Operation.
 - `bar.monitor` returns the current monitor widget text, which is the current bar position formatted according to the current configuration.
 - `bar.eta`: returns the current ETA widget text, formatted according to the current configuration.

--- a/alive_progress/core/progress.py
+++ b/alive_progress/core/progress.py
@@ -339,6 +339,10 @@ def __alive_bar(config, total=None, *, calibrate=None,
     stats = _Widget(stats_run, config.stats, stats_default)
     stats_end = _Widget(stats_end, config.stats_end, '({rate})' if stats.f[:-1] else '')
 
+    def set_end_widget(name, widget, value):
+        value = getattr(config_handler(**{name: value}), name)
+        widget.set(value)
+
     def get_receipt():
         buffer = io.StringIO()
         tbuf = terminal.get_term(buffer, True, 1000)  # large enough to not truncate.
@@ -347,6 +351,9 @@ def __alive_bar(config, total=None, *, calibrate=None,
         return buffer.getvalue().strip()
 
     bar_handle = __AliveBarHandle(pause_monitoring, set_title, set_text,
+                                  lambda value=None: set_end_widget('monitor_end', monitor_end, value),
+                                  lambda value=None: set_end_widget('elapsed_end', elapsed_end, value),
+                                  lambda value=None: set_end_widget('stats_end', stats_end, value),
                                   current, lambda: run.monitor_text, lambda: run.rate_text,
                                   lambda: run.eta_text, lambda: run.elapsed, get_receipt)
     set_text(), set_title()
@@ -384,10 +391,16 @@ def __alive_bar(config, total=None, *, calibrate=None,
 class _Widget:  # pragma: no cover
     def __init__(self, func, value, default):
         self.func = func
+        self.default = default
+        self.set(value)
+
+    def set(self, value):
+        """Set the widget format."""
+
         if isinstance(value, str):
             self.f = value
         elif value:
-            self.f = default
+            self.f = self.default
         else:
             self.f = ''
 
@@ -439,16 +452,20 @@ class __AliveBarHandle:
     current = _ReadOnlyProperty()
     text = _AssignFunction()
     title = _AssignFunction()
+    monitor_end = _AssignFunction()
+    elapsed_end = _AssignFunction()
+    stats_end = _AssignFunction()
     monitor = _ReadOnlyProperty()
     rate = _ReadOnlyProperty()
     eta = _ReadOnlyProperty()
     elapsed = _ReadOnlyProperty()
     receipt = _Function()
 
-    def __init__(self, pause, set_title, set_text, get_current, get_monitor, get_rate, get_eta,
-                 get_elapsed, get_receipt):
+    def __init__(self, pause, set_title, set_text, set_monitor_end, set_elapsed_end, set_stats_end,
+                 get_current, get_monitor, get_rate, get_eta, get_elapsed, get_receipt):
         self._handle, self._pause, self._current = None, pause, get_current
         self._title, self._text = set_title, set_text
+        self._monitor_end, self._elapsed_end, self._stats_end = set_monitor_end, set_elapsed_end, set_stats_end
         self._monitor, self._rate, self._eta = get_monitor, get_rate, get_eta
         self._elapsed, self._receipt = get_elapsed, get_receipt
 

--- a/tests/core/test_progress.py
+++ b/tests/core/test_progress.py
@@ -75,3 +75,42 @@ def test_progress_it(enrich_print, total, scale, capsys):
 
     alive_it_case(n if total else None)
     assert capsys.readouterr().out.strip() == DATA[enrich_print, total, False, scale]
+
+
+def test_progress_bar_can_hide_receipt_widgets(capsys):
+    config = config_handler(length=3, bar='classic', force_tty=False, file=sys.stdout)
+
+    with __alive_bar(config, 1, _testing=True) as bar:
+        bar()
+        bar.monitor_end = False
+        bar.elapsed_end = False
+        bar.stats_end = False
+
+    assert capsys.readouterr().out.strip() == '[===]'
+
+
+def test_progress_bar_can_customize_receipt_widgets(capsys):
+    config = config_handler(length=3, bar='classic', force_tty=False, file=sys.stdout)
+
+    with __alive_bar(config, 1, _testing=True) as bar:
+        bar()
+        bar.monitor_end = '{count} done'
+        bar.elapsed_end = 'after {elapsed}'
+        bar.stats_end = 'at {rate}'
+
+    assert capsys.readouterr().out.strip() == '[===] 1 done after 1.2s at 9876.54/s'
+
+    bar.monitor_end = False
+    bar.elapsed_end = False
+    bar.stats_end = False
+    assert bar.receipt() == '[===]'
+
+
+def test_progress_bar_validates_dynamic_receipt_widgets(capsys):
+    config = config_handler(length=3, bar='classic', force_tty=False, file=sys.stdout)
+
+    with __alive_bar(config, 1, _testing=True) as bar, \
+            pytest.raises(ValueError, match='Expected only the fields'):
+        bar.elapsed_end = '{rate}'
+
+    capsys.readouterr()


### PR DESCRIPTION
Fixes #297.

This exposes `monitor_end`, `elapsed_end`, and `stats_end` as assignable/callable bar-handle properties. Changes made during a run affect the final receipt, and changes made afterward affect `bar.receipt()`.

Dynamic values use the existing configuration validators, so format strings follow the same placeholder rules as constructor options.

Tests:
- `pytest -q` (566 passed)
- Ruff on the touched Python files reports the same 10 existing findings as `upstream/main`

AI assistance: Codex was used to implement and validate this change.
