### PR TITLE
Add OSC 9;4 terminal progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ These are the options - default values in brackets:
 - `refresh_secs`: [`0`] forces the refresh period to this, `0` is the reactive visual feedback
 - `ctrl_c`: [`True`] if False, disables CTRL+C (captures it)
 - `dual_line`: [`False`] if True, places the text below the bar
+- `terminal_progress`: [`False`] reports progress to compatible terminals using OSC 9;4
 - `unit`: any text that labels your entities
 - `scale`: the scaling to apply to units: `None`, `SI`, `IEC`, or `SI2`
   <br> ↳ supports aliases: `False` or `''` -> `None`, `True` -> `SI`, `10` or `'10'` -> `SI`, `2` or `'2'` -> `IEC`

--- a/alive_progress/core/configuration.py
+++ b/alive_progress/core/configuration.py
@@ -139,7 +139,7 @@ def _file_input_factory():
 Config = namedtuple('Config', 'title length max_cols spinner bar unknown force_tty disable manual '
                               'enrich_print enrich_offset receipt receipt_text monitor elapsed stats '
                               'title_length spinner_length refresh_secs monitor_end elapsed_end '
-                              'stats_end ctrl_c dual_line unit scale precision file')
+                              'stats_end ctrl_c dual_line terminal_progress unit scale precision file')
 
 
 def create_config():
@@ -169,6 +169,7 @@ def create_config():
             refresh_secs=0,
             ctrl_c=True,
             dual_line=False,
+            terminal_progress=False,
             unit='',
             scale=None,
             precision=1,
@@ -248,6 +249,7 @@ def create_config():
             refresh_secs=_float_input_factory(0, 60 * 60 * 24),  # maximum 24 hours.
             ctrl_c=_bool_input_factory(),
             dual_line=_bool_input_factory(),
+            terminal_progress=_bool_input_factory(),
             # title_effect=_enum_input_factory(),  # TODO someday.
             unit=_text_input_factory(),
             scale=_options_input_factory((None, 'SI', 'IEC', 'SI2'),

--- a/alive_progress/core/progress.py
+++ b/alive_progress/core/progress.py
@@ -112,6 +112,7 @@ def alive_bar(total: Optional[int] = None, *, calibrate: Optional[int] = None, *
             refresh_secs (int): forces the refresh period, `0` for the reactive visual feedback
             ctrl_c (bool): if False, disables CTRL+C (captures it)
             dual_line (bool): if True, places the text below the bar
+            terminal_progress (bool): if True, reports progress to compatible terminals via OSC 9;4
             unit (str): any text that labels your entities
             scale (any): the scaling to apply to units: 'SI', 'IEC', 'SI2'
             precision (int): how many decimals do display when scaling
@@ -140,7 +141,8 @@ def __alive_bar(config, total=None, *, calibrate=None,
         with cond_refresh:
             while thread:
                 event_renderer.wait()
-                alive_repr(term, next(spinner_player), spinner_suffix)
+                alive_repr(term, next(spinner_player), spinner_suffix,
+                           report_progress=config.terminal_progress)
                 cond_refresh.wait(1. / fps(run.rate))
 
     run.rate, run.init, run.elapsed, run.percent = 0., 0., 0., 0.
@@ -158,8 +160,15 @@ def __alive_bar(config, total=None, *, calibrate=None,
             run.elapsed = time.perf_counter() - run.init
             run.rate = gen_rate.send((processed(), run.elapsed))
 
-    def alive_repr(out, spinner=None, spinner_suffix=None):
+    def alive_repr(out, spinner=None, spinner_suffix=None, *, report_progress=False):
         main_update_hook()
+
+        if report_progress:
+            if total or config.manual:
+                percent = round(min(1., run.percent) * 100)
+                out.progress(1, percent)
+            else:
+                out.progress(3)
 
         fragments = (run.title, bar_repr(run.percent), bar_suffix, spinner, spinner_suffix,
                      monitor(), elapsed(), stats(), *run.text)
@@ -218,7 +227,7 @@ def __alive_bar(config, total=None, *, calibrate=None,
     def pause_monitoring():
         event_renderer.clear()
         offset = stop_monitoring()
-        alive_repr(term)
+        alive_repr(term, report_progress=config.terminal_progress)
         term.write('\n')
         term.flush()
         try:
@@ -373,10 +382,12 @@ def __alive_bar(config, total=None, *, calibrate=None,
             if not config.receipt_text:
                 set_text()
             term.clear_end_screen()
-            alive_repr(term)
+            alive_repr(term, report_progress=config.terminal_progress)
             term.write('\n')
         else:
             term.clear_line()
+        if config.terminal_progress:
+            term.progress(0)
         main_update_hook = _noop  # freeze the final elapsed, rate and eta values.
         term.flush()
 

--- a/alive_progress/utils/terminal/__init__.py
+++ b/alive_progress/utils/terminal/__init__.py
@@ -19,6 +19,7 @@ def _create(mod, interactive):
         # directly from terminal impl.
         write=mod.write,
         flush=mod.flush,
+        progress=mod.progress,
         cols=mod.cols,
         carriage_return=mod.carriage_return,
         clear_line=mod.clear_line,

--- a/alive_progress/utils/terminal/jupyter.py
+++ b/alive_progress/utils/terminal/jupyter.py
@@ -20,7 +20,7 @@ def get_from(parent):
     # it seems spaces are appropriately handled to not wrap lines.
     _clear_line = f'\r{" " * cols()}\r'
 
-    from .void import factory_cursor_up, hide_cursor, show_cursor  # noqa
+    from .void import factory_cursor_up, hide_cursor, progress, show_cursor  # noqa
 
     flush = parent.flush
     write = parent.write

--- a/alive_progress/utils/terminal/non_tty.py
+++ b/alive_progress/utils/terminal/non_tty.py
@@ -6,7 +6,7 @@ def get_from(parent):
     def cols():
         return sys.maxsize  # do not truncate when there's no tty.
 
-    from .void import clear_end_line, clear_end_screen, clear_line  # noqa
+    from .void import clear_end_line, clear_end_screen, clear_line, progress  # noqa
     from .void import factory_cursor_up, hide_cursor, show_cursor  # noqa
 
     flush = parent.flush

--- a/alive_progress/utils/terminal/tty.py
+++ b/alive_progress/utils/terminal/tty.py
@@ -29,6 +29,9 @@ def new(original, max_cols):
     def factory_cursor_up(num):
         return _ansi_escape_sequence('A', num)  # sends cursor up: CSI {x}A.
 
+    def progress(state, percent=0):
+        write(f'\x1b]9;4;{state};{percent}\x07')
+
     clear_line = _ansi_escape_sequence('2K\r')  # clears the entire line: CSI n K -> with n=2.
     clear_end_line = _ansi_escape_sequence('K')  # clears line from cursor: CSI K.
     clear_end_screen = _ansi_escape_sequence('J')  # clears screen from cursor: CSI J.

--- a/alive_progress/utils/terminal/void.py
+++ b/alive_progress/utils/terminal/void.py
@@ -6,6 +6,10 @@ def flush():
     pass
 
 
+def progress(_state, _percent=0):
+    pass
+
+
 def _ansi_escape_sequence(_=''):
     def inner(_available=None):
         pass

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -114,6 +114,7 @@ def test_config_creation(handler):
     (dict(bar=BARS['solid']), {}),
     (dict(force_tty=False), {}),
     (dict(manual=True), {}),
+    (dict(terminal_progress=True), {}),
     (dict(enrich_print=False), {}),
     (dict(title_length=20), {}),
     (dict(scale=False, manual=True, enrich_print=False, title_length=10), dict(scale=None)),

--- a/tests/core/test_progress.py
+++ b/tests/core/test_progress.py
@@ -75,3 +75,27 @@ def test_progress_it(enrich_print, total, scale, capsys):
 
     alive_it_case(n if total else None)
     assert capsys.readouterr().out.strip() == DATA[enrich_print, total, False, scale]
+
+
+def test_progress_bar_reports_terminal_progress(capsys):
+    config = config_handler(length=3, bar='classic', force_tty=True,
+                            terminal_progress=True, file=sys.stdout)
+
+    with __alive_bar(config, 2, _testing=True) as bar:
+        bar()
+
+    output = capsys.readouterr().out
+    assert '\x1b]9;4;1;50\x07' in output
+    assert output.endswith('\x1b]9;4;0;0\x07')
+
+
+def test_progress_bar_reports_indeterminate_terminal_progress(capsys):
+    config = config_handler(length=3, bar='classic', force_tty=True,
+                            terminal_progress=True, file=sys.stdout)
+
+    with __alive_bar(config, _testing=True):
+        pass
+
+    output = capsys.readouterr().out
+    assert '\x1b]9;4;3;0\x07' in output
+    assert output.endswith('\x1b]9;4;0;0\x07')

--- a/tests/utils/test_terminal.py
+++ b/tests/utils/test_terminal.py
@@ -1,0 +1,21 @@
+import io
+
+from alive_progress.utils.terminal import non_tty, tty
+
+
+def test_tty_progress_writes_osc_9_4_sequence():
+    output = io.StringIO()
+    term = tty.new(output, 80)
+
+    term.progress(1, 42)
+
+    assert output.getvalue() == '\x1b]9;4;1;42\x07'
+
+
+def test_non_tty_progress_is_suppressed():
+    output = io.StringIO()
+    term = non_tty.get_from(tty.new(output, 80))
+
+    term.progress(1, 42)
+
+    assert output.getvalue() == ''


### PR DESCRIPTION
Adds opt-in `terminal_progress=True` support for OSC 9;4. Bounded/manual bars report percentages, unknown bars report indeterminate state, non-TTY/Jupyter output stays clean, and the terminal state is cleared on exit.

Fixes #314

Tests: 570 passed.
