### PR TITLE
Respect unavailable iterator length hints in alive_it

### DIFF
--- a/alive_progress/core/progress.py
+++ b/alive_progress/core/progress.py
@@ -7,6 +7,7 @@ import threading
 import time
 import io
 from contextlib import contextmanager
+from operator import length_hint
 from typing import Any, Callable, Optional, TypeVar
 from collections.abc import Collection, Iterable
 
@@ -574,8 +575,8 @@ DB updated |████████████████████| 100k/1
     if total is None and hasattr(it, '__len__'):
         total = len(it)
     it = iter(it)
-    if total is None and hasattr(it, '__length_hint__'):
-        total = it.__length_hint__()
+    if total is None:
+        total = length_hint(it)
     return __AliveBarIteratorAdapter(it, finalize, __alive_bar(config, total, calibrate=calibrate))
 
 

--- a/tests/core/test_progress.py
+++ b/tests/core/test_progress.py
@@ -75,3 +75,28 @@ def test_progress_it(enrich_print, total, scale, capsys):
 
     alive_it_case(n if total else None)
     assert capsys.readouterr().out.strip() == DATA[enrich_print, total, False, scale]
+
+
+@pytest.mark.parametrize('unavailable', [NotImplemented, TypeError])
+def test_progress_it_with_unavailable_length_hint(unavailable):
+    from alive_progress import alive_it
+
+    class Iterator:
+        def __init__(self):
+            self.items = iter(range(3))
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self.items)
+
+        def __length_hint__(self):
+            if unavailable is TypeError:
+                raise TypeError('length unavailable')
+            return unavailable
+
+    bar = alive_it(Iterator(), disable=True)
+
+    assert list(bar) == [0, 1, 2]
+    assert bar.current == 3


### PR DESCRIPTION
An iterator may decline a length hint by returning NotImplemented or raising TypeError, but alive_it currently propagates those results into a failing progress bar. Use operator.length_hint() to honor the standard fallback to unknown length. Explicit totals and the existing collection-length path stay unchanged.

Validation: Both original unavailable-hint regression cases failed (alive-red.log). Full suite: 565 passed in 4.13s (alive-green.log). Final import-order change rerun: all 26 test_progress.py tests passed.

Manual QA: PASS: four public alive_it scenarios render receipts and leave no threads

Limitations: macOS CPython 3.14.6. Other interpreter/OS matrices not run. operator.length_hint also enforces the standard integer/nonnegative hint contract; malformed custom hints may receive the standard error rather than prior ad hoc treatment.

AI disclosure: OpenAI Codex generated and locally tested this patch and regression tests.
